### PR TITLE
chore(dev): configure browsersync

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,17 @@
 {
   "presets": ["es2015", "react"],
-  "plugins": ["transform-object-rest-spread"]
+  "plugins": ["transform-object-rest-spread"],
+  "env": {
+    "development": {
+      "plugins": [
+        ["react-transform", {
+          "transforms": [{
+            "transform": "react-transform-hmr",
+            "imports": ["react"],
+            "locals": ["module"]
+          }]
+        }]
+      ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -30,9 +30,11 @@
     "babel-core": "^6.0.0",
     "babel-eslint": "^5.0.0-beta6",
     "babel-loader": "^6.0.0",
+    "babel-plugin-react-transform": "^2.0.0",
     "babel-plugin-transform-object-rest-spread": "^6.3.13",
     "babel-preset-es2015": "^6.0.0",
     "babel-preset-react": "^6.0.0",
+    "browser-sync": "^2.11.0",
     "css-loader": "^0.23.0",
     "cz-conventional-changelog": "^1.1.4",
     "eslint": "^1.10.3",
@@ -46,11 +48,13 @@
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
     "react-router": "^1.0.0",
+    "react-transform-hmr": "^1.0.1",
     "sass-loader": "^3.1.2",
     "style-loader": "^0.13.0",
     "surge": "^0.17.4",
     "webpack": "^1.12.2",
-    "webpack-dev-server": "^1.12.1"
+    "webpack-dev-middleware": "^1.4.0",
+    "webpack-hot-middleware": "^2.6.0"
   },
   "config": {
     "commitizen": {

--- a/server.js
+++ b/server.js
@@ -1,23 +1,30 @@
+const browserSync = require('browser-sync');
 const webpack = require('webpack');
-const WebpackDevServer = require('webpack-dev-server');
+const webpackDevMiddleware = require('webpack-dev-middleware');
+const webpackHotMiddleware = require('webpack-hot-middleware');
+
 const config = require('./webpack-dev.config');
-const portfinder = require('portfinder');
+const bundler = webpack(config);
 
-const host = process.env.HOST || 'localhost';
+browserSync({
+  server: {
+    baseDir: 'docs/src/www',
 
-portfinder.getPort((err, port) => {
-  if (err) {
-    throw err;
+    middleware: [
+      webpackDevMiddleware(bundler, {
+        publicPath: config.output.publicPath,
+        stats: { colors: true }
+      }),
+
+      webpackHotMiddleware(bundler)
+    ],
+
+    // Watch these files for changes. No need to watch *.js because
+    // webpack takes care of it for us with hot module replacement,
+    // with fallback to full page reload.
+    files: [
+      'docs/src/www/scss/*.scss',
+      'docs/src/www/*.html'
+    ]
   }
-
-  config.entry = [`webpack-dev-server/client?http://${host}:${port}`].concat(config.entry);
-
-  new WebpackDevServer(webpack(config), config.devServer)
-    .listen(port, host, (err) => {
-      if (err) {
-        throw err;
-      }
-
-      console.log(`Listening at ${host}:${port}`);
-    })
 });

--- a/webpack-dev.config.js
+++ b/webpack-dev.config.js
@@ -5,11 +5,13 @@ module.exports = {
 
   entry: [
     'webpack/hot/dev-server',
+    'webpack-hot-middleware/client',
     path.join(__dirname, './docs/src/app/app.js')
   ],
 
   output: {
     path: path.join(__dirname, './docs/src/www'),
+    publicPath: '/',
     filename: 'app.js'
   },
 
@@ -22,7 +24,7 @@ module.exports = {
 
   debug: true,
 
-  devtool: 'inline-source-map',
+  devtool: '#eval-source-map',
 
   devServer: {
     contentBase: path.join(__dirname, './docs/src/www'),
@@ -30,7 +32,9 @@ module.exports = {
   },
 
   plugins: [
-    new webpack.HotModuleReplacementPlugin()
+    new webpack.optimize.OccurenceOrderPlugin(),
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NoErrorsPlugin()
   ],
 
   module: {


### PR DESCRIPTION
@dstack @StommePoes @aaronkaka @umahaea 

Configured [Browsersync](https://www.browsersync.io/) to make local cross browser/device testing easier, and for consistency with Elements. Running `npm start` will fire up the local dev server using Browsersync. It will find an available port (starting with 3000); typically the browsersync server runs on the next consecutive port (e.g., 3001).