### PR TITLE
fix: Handle IE override of button input type.

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -2,7 +2,8 @@ import React, { PropTypes } from 'react';
 
 const BUTTON_TYPES = {
   PRIMARY: 'primary',
-  LINK: 'link'
+  LINK: 'link',
+  SUBMIT: 'submit'
 };
 
 const BUTTON_SIZES = {
@@ -14,6 +15,12 @@ function Button(props) {
   let classes = ['pe-btn'];
 
   if (props.type) {
+
+    // Handle IE overriding element type
+    if (props.type === BUTTON_TYPES.SUBMIT) {
+      props.type = BUTTON_TYPES.PRIMARY;
+    }
+
     classes = classes.concat([`pe-btn--${props.type}`]);
   }
 


### PR DESCRIPTION
It appears that IE overrides the input type on button elements.  Is this a valid way to handle this in your opinion, or will we want to style 'submit' buttons differently than any other button?