### PR TITLE
Coveralls v2

### DIFF
--- a/.mocha
+++ b/.mocha
@@ -1,2 +1,1 @@
 --compilers js:babel-core/register
-@(src)/**/*-test.js

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "gh-pages": "node ./npm_scripts/gh-pages.js",
     "deploy-wip": "node ./npm_scripts/deploy-wip.js",
     "release": "./npm_scripts/release.sh",
-    "compile" : "babel --stage 0 -d dist/ src/",
-    "istanbul": "npm run compile && istanbul cover --dir coverage/istanbul _mocha dist/__tests__/*.js --report lcovonly",
-    "coveralls": "cat coverage/istanbul/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
-    "test-ci": "npm run istanbul && npm run coveralls && rm -rf dist",
-    "test": "npm run istanbul && rm -rf dist"
+    "compile": "babel ./src --out-dir ./lib --source-maps both",
+    "istanbul": "npm run compile && babel-node ./node_modules/istanbul/lib/cli.js cover _mocha -- ./test",
+    "coveralls": "cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
+    "test-ci": "npm run istanbul && npm run coveralls",
+    "test": "npm run istanbul"
   },
   "license": "MIT",
   "devDependencies": {
@@ -33,7 +33,7 @@
     "babel-eslint": "^5.0.0-beta6",
     "babel-loader": "^6.0.0",
     "babel-plugin-transform-object-rest-spread": "^6.3.13",
-    "babel-preset-es2015": "^6.0.0",
+    "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.0.0",
     "coveralls": "^2.11.9",
     "css-loader": "^0.23.0",

--- a/test/Button-test.js
+++ b/test/Button-test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import expect from 'expect';
 import { shallow } from 'enzyme';
-import { Button } from '../';
+import { Button } from '../lib';
 
 describe('Button', () => {
 

--- a/test/Button-test.js
+++ b/test/Button-test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import expect from 'expect';
 import { shallow } from 'enzyme';
-import { Button } from '../lib';
+import { Button } from '../lib'; 
 
 describe('Button', () => {
 

--- a/test/Card-test.js
+++ b/test/Card-test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import expect from 'expect';
 import { shallow } from 'enzyme';
-import { Card, CardHeader, CardContent } from '../';
+import { Card, CardHeader, CardContent } from '../lib';
 
 describe('Card', () => {
 

--- a/test/Label-test.js
+++ b/test/Label-test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import expect from 'expect';
 import { shallow } from 'enzyme';
-import { Label } from '../';
+import { Label } from '../lib';
 
 describe('Label', () => {
 


### PR DESCRIPTION
Modified .mocha file
Modified package.json to use the generated lib directory for running coverage
Moved tests into a separate 'test' parent directory -- since thats what mocha picks up automatically without the need to configure a special directory.
Modified tests to import from compiled lib instead of src.