### PR TITLE
Calendar accessibility additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,8 @@ The static demo site is scripted to deploy to GitHub Pages (gh-pages branch).
 
 ## Guidelines
 
-All submissions must be via pull request and approved before the pearson-design-accelerator@pearson.com team will merge 
-and allow it to enter the release process. All submissions must pass this project's linting, test with 100% code coverage, 
-and be compatible with the version(s) of React approved for the Pearson User Experience Platform.
+Please review the [guidelines](https://github.com/Pearson-Higher-Ed/docs/blob/master/origami-contributions.md) for contributing before getting started.
+All submissions must be via pull request and approved before the pearson-design-accelerator@pearson.com team will merge and allow it to enter the release process. All submissions must pass this project's linting, test with 100% code coverage, and be compatible with the version(s) of React approved for the Pearson User Experience Platform.
 
 ## License
 

--- a/docs/src/app/components/containers/components/DateUtils.js
+++ b/docs/src/app/components/containers/components/DateUtils.js
@@ -117,26 +117,6 @@ export function isDayInRange(day, range) {
     (from && to && isDayBetween(day, from, to));
 }
 
-
-export function isDayExists(day) {
-
-  let value = false;
-  let dueDates = ['Tue Jun 07 2016 12:00:00 GMT+0530 (IST)', 'Tue Jun 28 2016 12:00:00 GMT+0530 (IST)'];
-
-  for (let i = 0; i < dueDates.length ; i++) {
-    let internalVariable = dueDates[i];
-    if (internalVariable === day) {
-      value = true;
-      i = dueDates.length;
-    }
-  }
-
-  return value;
-}
-
-
-
-
 export default {
   addDayToRange,
   addMonths,
@@ -144,6 +124,5 @@ export default {
   isSameDay,
   isDayInRange,
   isDayBetween,
-  isPastDay,
-  isDayExists
+  isPastDay
 }

--- a/docs/src/app/components/containers/components/Helpers.js
+++ b/docs/src/app/components/containers/components/Helpers.js
@@ -1,6 +1,6 @@
 
-import { clone } from "./DateUtils";
-import { getFirstDayOfWeek } from "./LocaleUtils";
+import { clone } from './DateUtils';
+import { getFirstDayOfWeek } from './LocaleUtils';
 
 export function cancelEvent(e) {
   e.preventDefault();

--- a/docs/src/app/components/containers/components/LocaleUtils.js
+++ b/docs/src/app/components/containers/components/LocaleUtils.js
@@ -2,23 +2,19 @@ import moment from 'moment';
 
 export function formatDay(day, locale) {
 
-  return moment(day).locale(locale).format("ddd ll");
+  return moment(day).locale(locale).format('ddd ll');
 }
 
 export function formatMonthTitle(date, locale) {
 
-  return moment(date).locale(locale).format("MMMM YYYY");
+  return moment(date).locale(locale).format('MMMM YYYY');
 }
 
 export function formatWeekdayShort(day, locale) {
 
-  let weekDayShort;
+  let weekDayShort = moment().locale(locale).weekday(day).format('dd');
   if (locale === 'en') {
-    // if the loacle is default - english calendar then update as 'spec'
-    weekDayShort = moment().locale(locale).weekday(day).format("dd").charAt(0);
-
-  } else {
-    weekDayShort = moment().locale(locale).weekday(day).format("dd");
+    weekDayShort = moment().locale(locale).weekday(day).format('dd').charAt(0);
   }
 
   return weekDayShort;
@@ -26,12 +22,12 @@ export function formatWeekdayShort(day, locale) {
 
 export function formatWeekdayLong(day, locale) {
 
-  return moment().locale(locale).weekday(day).format("dddd");
+  return moment().locale(locale).weekday(day).format('dddd');
 }
 
 export function getFirstDayOfWeek(locale) {
 
-  let localeData = moment.localeData(locale);
+  const localeData = moment.localeData(locale);
 
   let firstDayOfWeek = localeData;
 

--- a/docs/src/app/components/containers/components/SimpleCalendar.js
+++ b/docs/src/app/components/containers/components/SimpleCalendar.js
@@ -1,6 +1,6 @@
-import React from "react";
-import DayPicker from "./DayPicker";
-import DateUtils from "./DateUtils";
+import React from 'react';
+import DayPicker from './DayPicker';
+import DateUtils from './DateUtils';
 
 
 export default class SimpleCalendar extends React.Component {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "surge": "^0.17.4",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.12.1",
-    "moment":"2.12.0"
+    "moment": "2.12.0",
+    "uuid": "2.0.2" 
   },
   "config": {
     "commitizen": {

--- a/src/calendar/Calendar.js
+++ b/src/calendar/Calendar.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import SimpleCalendar from "../../docs/src/app/components/containers/components/SimpleCalendar";
+import SimpleCalendar from '../../docs/src/app/components/containers/components/SimpleCalendar';
 
 function Calendar(props) {
   return (

--- a/test/Calendar-test.js
+++ b/test/Calendar-test.js
@@ -2,15 +2,15 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import {expect} from "chai";
 
-const DayPicker = require("../docs/src/app/components/containers/components/DayPicker").default;
+const DayPicker = require('../docs/src/app/components/containers/components/DayPicker').default;
 
-describe("DayPicker", () => {
+describe('DayPicker', () => {
 
   beforeEach(function() {
     this.wrapper = shallow(<DayPicker>Test</DayPicker>);
   });
 
-  it("has the default props properly set", () => {
+  it('has the default props properly set', () => {
     const dayPicker = <DayPicker />;
     const now = new Date();
     expect(dayPicker.props.initialMonth.getMonth()).to.equal(now.getMonth());


### PR DESCRIPTION
@wyseguyonline @gayankumara @umahaea ... take a look and see if anything jumps out at you.

- Decided to do last part of DES-348 here since I was playing with compounds (update guidelines)

- I moved the buttons to after the h3 to match the Elements calendar. This meant removing the caption as a separate thing. 
- Changed some roles, added some roles and aria attributes (the h3 may not need the heading role but it should now announce itself when a user clicking a button updates the month).
- Had to remove the {...attributes} from the main render because it was giving me errors, not sure if that is the right thing to do (was getting this error https://facebook.github.io/react/warnings/unknown-prop.html)

TODO: localisation for the title and aria-label attribute strings!
Later TODO: keyboarding for moving through the dates with arrows.