### PR TITLE
fix: Icons, focusable 'no' to 'false', add eventing to dist, update d…

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Be sure to include the above script (a version of it that makes sense for your p
 
 1. Install [Git](https://git-scm.com/downloads).
 2. Install [Node 4.0.0 or greater](https://nodejs.org) - Need to run multiple versions of Node? Use [nvm](https://github.com/creationix/nvm).
-3. On a Mac? You're all set. If you're on Windows, complete the steps for your OS below.  
+3. On a Mac? You're all set. If you're on Windows, complete the steps for your OS below.
 
 **On Windows:**
 
@@ -70,19 +70,19 @@ elements into formatted strings.
 ### QA Testing
 
 QA may use the event harness to instantiate a component for testing using this format:
-
+```
   document.body.dispatchEvent(new CustomEvent('o.InitCompounds', {
     detail: {
       elementId     : 'app',
       componentName : 'Button',
       props         : {
-                       btnType :'primary',        
-                       btnSize :'xlarge',           
+                       btnType :'primary',
+                       btnSize :'xlarge',
                        children:'hi there'
                       }
     }
   }));
-
+```
 ## Local Linking to Elements SDK
 
 When you need to work with a local version of Elements SDK that has not been published, you can utilize **npm link**.

--- a/demo/main.js
+++ b/demo/main.js
@@ -15,9 +15,7 @@ export default class Compounds {
 
   init(config) {
 
-    const component = config.componentName
-
-    const reactElement = React.createElement(CompoundsSDK[component], config.props, config.props.children)
+    const reactElement = React.createElement(CompoundsSDK[config.componentName], config.props, config.props.children)
 
     ReactDOM.render( reactElement, document.getElementById(config.elementId) );
   }

--- a/src/Icon.js
+++ b/src/Icon.js
@@ -13,7 +13,7 @@ const Icon = (props) => {
            xmlns = "http://www.w3.org/2000/svg"
            xmlnsXlink = "http://www.w3.org/1999/xlink"
            role = "img"
-           focusable = "no"
+           focusable = "false"
            aria-labelledby = {i_id}
            className = {icon_class}>
         <title id = {i_id}>{props.children}</title>
@@ -27,7 +27,7 @@ const Icon = (props) => {
            xmlns = "http://www.w3.org/2000/svg"
            xmlnsXlink = "http://www.w3.org/1999/xlink"
            aria-hidden = "true"
-           focusable = "no"
+           focusable = "false"
            className = {icon_class}>
         <use xlinkHref = {'#' + props.name}></use>
       </svg>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   entry: {
    dev  : ['webpack/hot/dev-server', './demo/demo.js', './demo/main.js'],
-   dist : ['./Compounds.js']
+   dist : ['./Compounds.js','./demo/main.js']
   },
   output: {
     path          : './',


### PR DESCRIPTION
…ocs to highlight qa event, dist to dev package in index.html


i had put the eventing only in the dev package... ejaz uses the dist.... so i included the main.js file in the webpack dist.

also, i updated the Icons file from focusable 'no' to 'false' as mallory pointed out.

and i put some highlighting around the qa event in the Readme to make it look nice.