### PR TITLE
fix: If passed in a different start day, the aria-label follows with …

### DIFF
--- a/src/Calendar/Calendar.js
+++ b/src/Calendar/Calendar.js
@@ -42,7 +42,7 @@ export default class Calendar extends Component {
       selectedMonth: newSelectedDt ? newSelectedDt.getMonth() : date.getMonth(),
       selectedDate: newSelectedDt ? newSelectedDt.getDate() : date.getDate(),
       selectedDt: newSelectedDt || new Date(date.getFullYear(), date.getMonth(), date.getDate()),
-      startDay: weekStartDay,
+      weekStartDay: weekStartDay,
       minDate: minDate ? minDate : null,
       secondaryDate: secondaryDate ? secondaryDate : [],
       disablePast: disablePast ? disablePast : false,
@@ -218,7 +218,7 @@ export default class Calendar extends Component {
   }
 
   render() {
-    const { monthNamesFull, month, year, dayNames, startDay, daysInMonth,
+    const { monthNamesFull, month, year, dayNames, weekStartDay, daysInMonth,
             firstOfMonth, selectedDate, disablePast, minDate, dayNamesFull,
             contrast, secondaryDate, selectedDt } = this.state;
 
@@ -239,7 +239,7 @@ export default class Calendar extends Component {
             contrast={contrast}
             dayNames={dayNames}
             dayNamesFull={dayNamesFull}
-            startDay={startDay} />
+            weekStartDay={weekStartDay} />
 
           <Dates
             selectedDt={selectedDt}
@@ -251,7 +251,7 @@ export default class Calendar extends Component {
             daysInMonth={daysInMonth}
             dayNamesFull={dayNamesFull}
             firstOfMonth={firstOfMonth}
-            startDay={startDay}
+            weekStartDay={weekStartDay}
             onSelect={this.selectDate}
             disablePast={disablePast}
             minDate={minDate}

--- a/src/Calendar/components/Dates.js
+++ b/src/Calendar/components/Dates.js
@@ -23,7 +23,7 @@ export default class Dates extends Component {
     const weekStack = Array(...{ length: 7 }).map(Number.call, Number);
     const { contrast, daysInMonth, firstOfMonth, year, monthNames, month, selectedDate,
             disablePast, minDate, onSelect, secondaryDate, dayNamesFull,
-            selectedDt } = this.props;
+            selectedDt, weekStartDay } = this.props;
     const dayContrast = contrast ? 'date-inverse' :'';
     const disabledContrast = contrast ? '-inverse' : '';
     const that = this;
@@ -37,7 +37,7 @@ export default class Dates extends Component {
 
     className = rows === 6 ? 'pe-cal-dates' : 'pe-cal-dates pe-cal-fix';
     haystack = Array(...{ length: rows }).map(Number.call, Number);
-    day = this.props.startDay + 1 - first;
+    day = this.props.weekStartDay + 1 - first;
     while (day > 1) {
       day -= 7;
     }
@@ -89,7 +89,7 @@ export default class Dates extends Component {
                          <div className={`pe-cal-cell-square ${isSecondaryDate ? 'secondary-date':''} ${newSelectedDtClass}`}
                             id={`day${d}`}
                             role="gridcell"
-                            aria-label={`${dayNamesFull[i]} ${monthNames[month]} ${d}`}
+                            aria-label={`${dayNamesFull[(i + weekStartDay) % 7]} ${monthNames[month]} ${d}`}
                             aria-current={isCurrentDate ? 'date' : null}
                             tabIndex="-1"
                             onClick={onSelect.bind(that, year, month, d)}

--- a/src/Calendar/components/WeekDays.js
+++ b/src/Calendar/components/WeekDays.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 export default class WeekDays extends Component {
 
   render() {
-    const { dayNamesFull, dayNames, startDay, contrast } = this.props;
+    const { dayNamesFull, dayNames, weekStartDay, contrast } = this.props;
     const dayNumbers = Array(...{ length: 7 }).map(Number.call, Number);
     const inverseColor = contrast ? 'inverse-dayNames' :'';
 
@@ -14,8 +14,8 @@ export default class WeekDays extends Component {
             <div className={`pe-cal-cell pe-label--small pe-cal-cell-dayNames ${inverseColor}`}
                  key={`weekday${i}`}
             >
-              <abbr title={dayNamesFull[(startDay + i) % 7]}>
-                {dayNames[(startDay + i) % 7]}
+              <abbr title={dayNamesFull[(weekStartDay + i) % 7]}>
+                {dayNames[(weekStartDay + i) % 7]}
               </abbr>
             </div>
           );

--- a/test/shell_scripts/run_tests.sh
+++ b/test/shell_scripts/run_tests.sh
@@ -5,7 +5,7 @@ echo "Trigger the Selenium tests for rebrand branch: ux-test-platform repo...."
 #Step 1: API to trigger the ux-test-platform build with the below config
 body="{
 \"request\": {
-\"message\": \"feat(compounds): Run Compounds SDK V0 Tests\",
+\"message\": \"feat(compounds): Run CI tests for $TRAVIS_BRANCH\",
 \"branch\":\"rebrand\",
 \"config\": {
 \"script\": [


### PR DESCRIPTION
…the appropriate full day name

While doing screen reader testing, Jack discovered that their French calendars, which started with Monday, were lagging behind one day on what the screen reader announced.  This fixes that.