### PR TITLE
Console changes

### DIFF
--- a/demo/demoPages/TablePage.js
+++ b/demo/demoPages/TablePage.js
@@ -11,156 +11,188 @@ const sixteen = {paddingLeft: 16};
 const twentyFour = {paddingLeft: 24};
 const thirtyTwo = {paddingLeft: 32};
 
-const TablePage = () => (
-  <div className="displaySection">
-    <h2><a href="http://pearson-higher-ed.github.io/design/c/tables/" target="_blank">Table</a></h2>
-    <div className="code">
-      <h3>Table props</h3>
-      <ul>
-        <li className="li-props">children:Node</li>
-        <li className="li-props">sortable:Boolean</li>
-        <li className="li-props">Applies the appropriate styles to a sortable table. If you are using a sortable table, <br/>
-          <i>TableHeaderCell</i> and <i>TableRowCell</i> must be self closing to get the pe-checkbox to render.
-        </li>
-        <li className="li-props">selectable:Boolean</li>
-        <li className="li-props">Applies the appropriate styles to a selectable table.
-          Both sortable and selectable can be used simultaneously.
-        </li>
-        <li className="li-props">insertCaption:Boolean</li>
-        <li className="li-props">Inserts a {`<caption>`} element into the <i>Table</i>.</li>
-        <li className="li-props">captionText:String</li>
-        <li className="li-props">**Only needed if <i>insertCaption</i> is present**. Defaults to null.</li>
-      </ul>
-      <h3>TableBody props</h3>
-      <ul>
-        <li className="li-props">children:Node</li>
-      </ul>
-      <h3>TableHead props</h3>
-      <ul>
-        <li className="li-props">children:Node</li>
-      </ul>
-      <h3>TableHeaderCell props</h3>
-      <ul>
-        <li className="li-props">children:Node</li>
-        <li className="li-props">scope:String</li>
-        <li className="li-props">Scope specifies whether the cell is a header
-          for a column, row, or group of columns or rows.  Defaults to "col".
-        </li>
-        <li className="li-props">columnSort:Function</li>
-        <li className="li-props">Applies the appropriate Icons to show the column is sortable and allows a sorting Function
-          to be passed in on the data.  <br/>Toggles from 'ASC' to 'DESC'.
-        </li>
-        <li className="li-props">alignCell:String </li>
-        <li className="li-props">Allows you to change the alignment of the contents of a cell.  Acceptable strings are 'center' and 'right'. <br/>
-          By default the element will maintain its left alignment.
-        </li>
-        <li className="li-props">**The following props are only necessary on Selectable tables.**</li>
-        <li className="li-props">inputId:String</li>
-        <li className="li-props">The inputId is passed to the checkbox and its label. This can only start with letters or an underscore (applies to all id&#39;s).</li>
-        <li className="li-props">inputLabel:String</li>
-        <li className="li-props">Label for the corresponding checkbox.</li>
-        <li className="li-props">containerId:String</li>
-        <li className="li-props">Assigns the id to the {`<div>`} containing the checkbox.  This id must also be passed
-          to the TableRowCell component and is <br/>referred to by the same prop name.
-        </li>
-      </ul>
-      <h3>TableRow props</h3>
-      <ul>
-        <li className="li-props">children:Node</li>
-      </ul>
-      <h3>TableRowCell props</h3>
-      <ul>
-        <li className="li-props">children:Node</li>
-        <li className="li-props">**The following props are only necessary on Selectable tables.**</li>
-        <li className="li-props">inputId:String</li>
-        <li className="li-props">The inputId is passed to the checkbox and its label</li>
-        <li className="li-props">containerId:String</li>
-        <li className="li-props">This must match what was passed into the TableHeaderCell component.  It is referenced here in the aria-labelledby of the checkbox.</li>
-        <li className="li-props">labelledbyCellId:String</li>
-        <li className="li-props">labelledbyCellId must match the cellId ans is passed into the aria-labelledby of the checkbox.</li>
-        <li className="li-props">cellId:String</li>
-        <li className="li-props">cellId needs to be passed to the TableRowCell that follows the checkbox.</li>
-      </ul>
-    </div> <br/>
+class TablePage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      itemSelected: ''
+    };
+  }
 
-    <h3>Example usage</h3>
+  handleColumnSort = (item) => {
+    return () => {
+      console.log(item);
+      this.setState(prevState => ({
+        itemSelected: item,
+        direction: prevState.direction === 'up' ? 'down' : 'up'
+      }));
+    }
+  }
 
-    <div className="code" style={{fontSize: 14}}>
-    {`<Table selectable sortable>`} <br/>
-      <div style={eight}>{`<TableHead>`}</div>
-        <div style={sixteen}>{`<TableRow>`}</div>
-          <div style={twentyFour}>{`<TableHeaderCell`}</div>
-            <div style={thirtyTwo}>{`inputId="comic_select_0"`}</div>
-            <div style={thirtyTwo}>{`containerId="comic_select"`}</div>
-            <div style={thirtyTwo}>{`inputLabel="Select"`}</div>
-          <div style={twentyFour}>{`/>`}</div>
-          <div style={twentyFour}>{`<TableHeaderCell columnSort={() => console.log('Hey')}>Comic</TableHeaderCell>`}</div>
-          <div style={twentyFour}>{`<TableHeaderCell>Main characters</TableHeaderCell>`}</div>
-          <div style={twentyFour}>{`<TableHeaderCell>Country</TableHeaderCell>`}</div>
-        <div style={sixteen}>{`</TableRow>`}</div>
-      <div style={eight}>{`</TableHead>`}</div>
-      <div style={eight}>{`<TableBody>`}</div>
-        <div style={sixteen}>{`<TableRow>`}</div>
-          <div style={twentyFour}>{`<TableRowCell`}</div>
-            <div style={thirtyTwo}>{`inputId="c1"`}</div>
-            <div style={thirtyTwo}>{`containerId="comic_select"`}</div>
-            <div style={thirtyTwo}>{`labelledbyCellId="sel_Spirou"`}</div>
-          <div style={twentyFour}>{`/>`}</div>
-          <div style={twentyFour}>{`<TableRowCell cellId="sel_Spirou">Spirou</TableRowCell>`}</div>
-          <div style={twentyFour}>{`<TableRowCell>Spirou, Fantasio</TableRowCell>`}</div>
-          <div style={twentyFour}>{`<TableRowCell>Belgium</TableRowCell>`}</div>
-        <div style={sixteen}>{`</TableRow>`}</div>
-        <div style={sixteen}>{`<TableRow>`}</div>
-          <div style={twentyFour}>{`<TableRowCell`}</div>
-            <div style={thirtyTwo}>{`inputId="c2"`}</div>
-            <div style={thirtyTwo}>{`containerId="comic_select"`}</div>
-            <div style={thirtyTwo}>{`labelledbyCellId="sel_sew"`}</div>
-          <div style={twentyFour}>{`/>`}</div>
-          <div style={twentyFour}>{`<TableRowCell cellId="sel_sew">Suske en Wiske</TableRowCell>`}</div>
-          <div style={twentyFour}>{`<TableRowCell>Suske, Wiske, Tante Sidonia, Krimson</TableRowCell>`}</div>
-          <div style={twentyFour}>{`<TableRowCell>Belgium</TableRowCell>`}</div>
-        <div style={sixteen}>{`</TableRow>`}</div>
-      <div style={eight}>{`</TableBody>`}</div>
-    {`</Table>`}
-    </div><br/>
+  getIconName = () => {
+    if (this.state.itemSelected === 'country') {
+      return this.state.direction === 'up' ? 'sort-down-18' : 'sort-up-18';
+    }
 
-    <Table selectable sortable>
-      <TableHead>
-        <TableRow>
-          <TableHeaderCell
-            inputId="comic_select_0"
-            containerId="comic_select"
-            inputLabel="Select"
-          />
-          <TableHeaderCell columnSort={() => console.log('Hey')}>Comic</TableHeaderCell>
-          <TableHeaderCell>Main characters</TableHeaderCell>
-          <TableHeaderCell>Country</TableHeaderCell>
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        <TableRow>
-          <TableRowCell
-            inputId="c1"
-            containerId="comic_select"
-            labelledbyCellId="sel_Spirou"
-          />
-          <TableRowCell cellId="sel_Spirou">Spirou</TableRowCell>
-          <TableRowCell>Spirou, Fantasio</TableRowCell>
-          <TableRowCell>Belgium</TableRowCell>
-        </TableRow>
-        <TableRow>
-          <TableRowCell
-            inputId="c2"
-            containerId="comic_select"
-            labelledbyCellId="sel_sew"
-          />
-          <TableRowCell cellId="sel_sew">Suske en Wiske</TableRowCell>
-          <TableRowCell>Suske, Wiske, Tante Sidonia, Krimson</TableRowCell>
-          <TableRowCell>Belgium</TableRowCell>
-        </TableRow>
-      </TableBody>
-    </Table>
-  </div>
-);
+    return  'sortable-18';
+  }
+
+  render() {
+    return (
+      <div className="displaySection">
+        <h2><a href="http://pearson-higher-ed.github.io/design/c/tables/" target="_blank">Table</a></h2>
+        <div className="code">
+          <h3>Table props</h3>
+          <ul>
+            <li className="li-props">children:Node</li>
+            <li className="li-props">sortable:Boolean</li>
+            <li className="li-props">Applies the appropriate styles to a sortable table. If you are using a sortable table, <br/>
+              <i>TableHeaderCell</i> and <i>TableRowCell</i> must be self closing to get the pe-checkbox to render.
+            </li>
+            <li className="li-props">selectable:Boolean</li>
+            <li className="li-props">Applies the appropriate styles to a selectable table.
+              Both sortable and selectable can be used simultaneously.
+            </li>
+            <li className="li-props">insertCaption:Boolean</li>
+            <li className="li-props">Inserts a {`<caption>`} element into the <i>Table</i>.</li>
+            <li className="li-props">captionText:String</li>
+            <li className="li-props">**Only needed if <i>insertCaption</i> is present**. Defaults to null.</li>
+          </ul>
+          <h3>TableBody props</h3>
+          <ul>
+            <li className="li-props">children:Node</li>
+          </ul>
+          <h3>TableHead props</h3>
+          <ul>
+            <li className="li-props">children:Node</li>
+          </ul>
+          <h3>TableHeaderCell props</h3>
+          <ul>
+            <li className="li-props">children:Node</li>
+            <li className="li-props">scope:String</li>
+            <li className="li-props">Scope specifies whether the cell is a header
+              for a column, row, or group of columns or rows.  Defaults to "col".
+            </li>
+            <li className="li-props">columnSort:Function</li>
+            <li className="li-props">Applies the appropriate Icons to show the column is sortable and allows a sorting Function
+              to be passed in on the data.  <br/>Toggles from 'ASC' to 'DESC'.
+            </li>
+            <li className="li-props">alignCell:String </li>
+            <li className="li-props">Allows you to change the alignment of the contents of a cell.  Acceptable strings are 'center' and 'right'. <br/>
+              By default the element will maintain its left alignment.
+            </li>
+            <li className="li-props">**The following props are only necessary on Selectable tables.**</li>
+            <li className="li-props">inputId:String</li>
+            <li className="li-props">The inputId is passed to the checkbox and its label. This can only start with letters or an underscore (applies to all id&#39;s).</li>
+            <li className="li-props">inputLabel:String</li>
+            <li className="li-props">Label for the corresponding checkbox.</li>
+            <li className="li-props">containerId:String</li>
+            <li className="li-props">Assigns the id to the {`<div>`} containing the checkbox.  This id must also be passed
+              to the TableRowCell component and is <br/>referred to by the same prop name.
+            </li>
+            <li className="li-props">defaultIcon:String - defaultIcon to show</li>
+            <li className="li-props">iconName - control icon name yourself</li>
+          </ul>
+          <h3>TableRow props</h3>
+          <ul>
+            <li className="li-props">children:Node</li>
+          </ul>
+          <h3>TableRowCell props</h3>
+          <ul>
+            <li className="li-props">children:Node</li>
+            <li className="li-props">**The following props are only necessary on Selectable tables.**</li>
+            <li className="li-props">inputId:String</li>
+            <li className="li-props">The inputId is passed to the checkbox and its label</li>
+            <li className="li-props">containerId:String</li>
+            <li className="li-props">This must match what was passed into the TableHeaderCell component.  It is referenced here in the aria-labelledby of the checkbox.</li>
+            <li className="li-props">labelledbyCellId:String</li>
+            <li className="li-props">labelledbyCellId must match the cellId ans is passed into the aria-labelledby of the checkbox.</li>
+            <li className="li-props">cellId:String</li>
+            <li className="li-props">cellId needs to be passed to the TableRowCell that follows the checkbox.</li>
+          </ul>
+        </div> <br/>
+
+        <h3>Example usage</h3>
+
+        <div className="code" style={{fontSize: 14}}>
+        {`<Table selectable sortable>`} <br/>
+          <div style={eight}>{`<TableHead>`}</div>
+            <div style={sixteen}>{`<TableRow>`}</div>
+              <div style={twentyFour}>{`<TableHeaderCell`}</div>
+                <div style={thirtyTwo}>{`inputId="comic_select_0"`}</div>
+                <div style={thirtyTwo}>{`containerId="comic_select"`}</div>
+                <div style={thirtyTwo}>{`inputLabel="Select"`}</div>
+              <div style={twentyFour}>{`/>`}</div>
+              <div style={twentyFour}>{`<TableHeaderCell columnSort={() => console.log('Hey')}>Comic</TableHeaderCell>`}</div>
+              <div style={twentyFour}>{`<TableHeaderCell>Main characters</TableHeaderCell>`}</div>
+              <div style={twentyFour}>{`<TableHeaderCell>Country</TableHeaderCell>`}</div>
+            <div style={sixteen}>{`</TableRow>`}</div>
+          <div style={eight}>{`</TableHead>`}</div>
+          <div style={eight}>{`<TableBody>`}</div>
+            <div style={sixteen}>{`<TableRow>`}</div>
+              <div style={twentyFour}>{`<TableRowCell`}</div>
+                <div style={thirtyTwo}>{`inputId="c1"`}</div>
+                <div style={thirtyTwo}>{`containerId="comic_select"`}</div>
+                <div style={thirtyTwo}>{`labelledbyCellId="sel_Spirou"`}</div>
+              <div style={twentyFour}>{`/>`}</div>
+              <div style={twentyFour}>{`<TableRowCell cellId="sel_Spirou">Spirou</TableRowCell>`}</div>
+              <div style={twentyFour}>{`<TableRowCell>Spirou, Fantasio</TableRowCell>`}</div>
+              <div style={twentyFour}>{`<TableRowCell>Belgium</TableRowCell>`}</div>
+            <div style={sixteen}>{`</TableRow>`}</div>
+            <div style={sixteen}>{`<TableRow>`}</div>
+              <div style={twentyFour}>{`<TableRowCell`}</div>
+                <div style={thirtyTwo}>{`inputId="c2"`}</div>
+                <div style={thirtyTwo}>{`containerId="comic_select"`}</div>
+                <div style={thirtyTwo}>{`labelledbyCellId="sel_sew"`}</div>
+              <div style={twentyFour}>{`/>`}</div>
+              <div style={twentyFour}>{`<TableRowCell cellId="sel_sew">Suske en Wiske</TableRowCell>`}</div>
+              <div style={twentyFour}>{`<TableRowCell>Suske, Wiske, Tante Sidonia, Krimson</TableRowCell>`}</div>
+              <div style={twentyFour}>{`<TableRowCell>Belgium</TableRowCell>`}</div>
+            <div style={sixteen}>{`</TableRow>`}</div>
+          <div style={eight}>{`</TableBody>`}</div>
+        {`</Table>`}
+        </div><br/>
+
+        <div> {this.state.itemSelected.length ? 'Sorting by ' + this.state.itemSelected : ''} </div>
+        <Table selectable sortable>
+          <TableHead>
+            <TableRow>
+              <TableHeaderCell
+                inputId="comic_select_0"
+                containerId="comic_select"
+                inputLabel="Select"
+              />
+              <TableHeaderCell columnSort={this.handleColumnSort('comic')} defaultIcon="sort-up-18">Comic</TableHeaderCell>
+              <TableHeaderCell columnSort={this.handleColumnSort('character')}>Main characters</TableHeaderCell>
+              <TableHeaderCell columnSort={this.handleColumnSort('country')} iconName={this.getIconName()}>Country</TableHeaderCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            <TableRow>
+              <TableRowCell
+                inputId="c1"
+                containerId="comic_select"
+                labelledbyCellId="sel_Spirou"
+              />
+              <TableRowCell cellId="sel_Spirou">Spirou</TableRowCell>
+              <TableRowCell>Spirou, Fantasio</TableRowCell>
+              <TableRowCell>Belgium</TableRowCell>
+            </TableRow>
+            <TableRow>
+              <TableRowCell
+                inputId="c2"
+                containerId="comic_select"
+                labelledbyCellId="sel_sew"
+              />
+              <TableRowCell cellId="sel_sew">Suske en Wiske</TableRowCell>
+              <TableRowCell>Suske, Wiske, Tante Sidonia, Krimson</TableRowCell>
+              <TableRowCell>Belgium</TableRowCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </div>
+    );
+  }
+}
 
 export default TablePage;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pearson-compounds",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3805,7 +3805,12 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
         }
       }
     },
@@ -5725,7 +5730,15 @@
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "lodash": {
           "version": "4.16.6",
@@ -10807,7 +10820,12 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
         }
       }
     },
@@ -11114,7 +11132,10 @@
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
           "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "websocket-driver": "0.6.5"
+          }
         }
       }
     },
@@ -11901,7 +11922,12 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
         }
       }
     },
@@ -12221,25 +12247,51 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          }
         },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         },
         "yargs": {
           "version": "6.6.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
+          }
         },
         "yargs-parser": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          }
         }
       }
     },
@@ -12290,7 +12342,12 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          }
         },
         "supports-color": {
           "version": "3.2.3",
@@ -12305,13 +12362,31 @@
           "version": "6.6.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
+          }
         },
         "yargs-parser": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          }
         }
       }
     },

--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -23,8 +23,7 @@ export default class Dropdown extends Component {
 
     this.state = {
       open: false,
-      selectedItem: '',
-      buttonFocus: true
+      selectedItem: ''
     };
 
     this.toggleDropdown = this.toggleDropdown.bind(this);
@@ -166,7 +165,6 @@ export default class Dropdown extends Component {
         aria-controls={`${this.props.id.replace(' ', '_')}-dropdown`}
         aria-haspopup="true"
         btnIcon={btnIcon}
-        focus={this.state.buttonFocus}
         onClick={this.toggleDropdown}
         >
         {buttonLabel}

--- a/src/Dropdown/DropdownItem.js
+++ b/src/Dropdown/DropdownItem.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Icon from '../Icon'
 
-const DropdownItem = ({ url, label, type, selected, selectedName, checkmark }) => {
+const DropdownItem = ({ url, label, type, selected, selectedName, checkmark, onClick }) => {
   switch (type) {
     case 'divider':
       return (
@@ -21,7 +21,7 @@ const DropdownItem = ({ url, label, type, selected, selectedName, checkmark }) =
     case 'button':
       return (
         <li role="presentation" data-item={label}>
-          <button role="menuitem" className={checkmark ? 'checkmark' : ''} type="button" tabIndex="-1">
+          <button role="menuitem" className={checkmark ? 'checkmark' : ''} onClick={onClick} type="button" tabIndex="-1">
             {checkmark ?
                 <span style={{visibility: selected ? 'visible' : 'hidden'}}>
                   <Icon name="check-sm-18">{selectedName}</Icon>

--- a/src/Table/components/TableHeaderCell.js
+++ b/src/Table/components/TableHeaderCell.js
@@ -11,7 +11,8 @@ export default class TableHeaderCell extends Component {
     containerId: PropTypes.string,
     inputLabel: PropTypes.string,
     columnSort: PropTypes.func,
-    alignCell: PropTypes.oneOf(['center', 'right'])
+    alignCell: PropTypes.oneOf(['center', 'right']),
+    defaultIcon: PropTypes.string
   }
 
   static defaultProps = {
@@ -22,27 +23,20 @@ export default class TableHeaderCell extends Component {
     super(props)
 
     this.state = {
-      iconName: 'sortable-18'
+      iconName: this.props.defaultIcon || 'sortable-18'
     }
 
     this.selectAll = _selectAll.bind(this);
-    this.handleKey = _handleKey.bind(this);
   }
 
-  componentDidMount() {
-    document.addEventListener('keydown', this.handleKey);
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('keydown', this.handleKey);
-  }
-
-  componentDidUpdate() {
-    if (this.props.columnSort) this.props.columnSort();
+  isControlled() {
+    return this.props.iconName != null
   }
 
   iconToggle = () => {
     const { iconName } = this.state;
+    this.props.columnSort()
+
     if (iconName === 'sort-up-18') {
       return this.setState({ iconName: 'sort-down-18' })
     }
@@ -51,10 +45,10 @@ export default class TableHeaderCell extends Component {
   }
 
   render() {
-    const { children, scope, inputId, containerId, inputLabel, columnSort,
+    const { children, inputId, containerId, inputLabel, columnSort,
             alignCell } = this.props;
     const { selectable, sortable } = this.context;
-    const { iconName } = this.state;
+    const { iconName } = this.isControlled() ? this.props : this.state;
     const sortClass = sortable ? 'pe-table__sortable' :'';
     const columnAlignment = (alignCell === 'center' || alignCell === 'right')
                             ? ' pe-table__' + alignCell :'';
@@ -74,8 +68,7 @@ export default class TableHeaderCell extends Component {
           selectable && !children
             ? <div className="pe-checkbox"
                    id={containerId}
-                   onClick={this.selectAll}
-                   onKeyDown={this.handleKey}>
+                   onClick={this.selectAll}>
                 <input type="checkbox" id={inputId} />
                 <label htmlFor={inputId}>{inputLabel}</label>
                 <span>
@@ -104,11 +97,5 @@ function _selectAll() {
   const checkboxes = document.querySelectorAll('div.pe-checkbox input');
   for (let i = 1; i < checkboxes.length; i++) {
     checkboxes[i].checked = checkboxes[0].checked;
-  }
-}
-
-function _handleKey(e) {
-  if (e.which === 32) {
-    this.selectAll;
   }
 }


### PR DESCRIPTION
- the `columnSort` function was getting called multiple times when inside componentDidUpdate if multiple headers had it. Updating one caused the other to rerender and call the `columnSort` again and the result was an infinite loop

- the keydown listeners on global didn't seem to be necessary and the function they were calling didn't invoke the `selectAll` function properly; seemed like a bug so I cleaned it up. Along those same lines, hitting spacebar on a focused checkbox activates `onClick` so I also removed the `onKeyDown` prop from the input itself.

- cleaned up an unused variable

- added `defaultIcon`, though console won't use this -- i started going down this path and thought it might be a good feature but I can remove it

- added `iconName` (the reason we won't need `defaultIcon`) that lets us control what icon to display - we don't allow multiple sorts so we are going to want to reset the icons when a different header is sorted

- updated demo to use state when clicking on a header (to recreate `componentDidUpdate` bug) and to use `iconName` prop as an example