### PR TITLE
Calendar cleanup

### DIFF
--- a/demo/demoPages/DatePickerPage.js
+++ b/demo/demoPages/DatePickerPage.js
@@ -47,7 +47,7 @@ class DatePickerPage extends Component {
                 <li>time:Boolean  === "render datepicker as timepicker"</li>
                 <li>className:String  === "styles to pass to datepicker"</li>
                 <li>id:String === "A unique name for the datepicker"</li>
-                <li>dateFormat:String === "format for date/time entry"</li>
+                <li>dateFormat:String === "format for date/time entry. Defaults to mm/dd/yyyy."</li>
                 <li>inputState:String === "styles for input state, one of 'error','disabled','readOnly','default'"</li>
                 <li>labelText:String === "unique lable for the input field"</li>
                 <li>datePickerValue:Date/Time === "value to be displayed by the datepicker/timepicker"</li>
@@ -73,12 +73,11 @@ class DatePickerPage extends Component {
               infoMessage     = {text.textInputInfoMessage}
               errorMessage    = {text.textInputErrorMessage}
             />
-            <p className="code">{`<DatePicker id = "someGiantId" dateFormat = "mm/dd/yyyy" inputState = "default" labelText = "Select date" datepickerValue = {this.state.datepickerValue2} changeHandler = {() => console.log("DatePicker-(basic)-changed!!")} infoMessage = "${text.textInputInfoMessage}" errorMessage = "${text.textInputErrorMessage}" />`}</p>
+            <p className="code">{`<DatePicker id="someGiantId" inputState = "default" labelText = "Select date" datepickerValue = {this.state.datepickerValue2} changeHandler = {() => console.log("DatePicker-(basic)-changed!!")} infoMessage = "${text.textInputInfoMessage}" errorMessage = "${text.textInputErrorMessage}" />`}</p>
 
             <h2>DatePicker (range): </h2>
             <DatePicker
               id              = "someGiantId2"
-              dateFormat      = "mm/dd/yyyy"
               inputState      = {inputState}
               labelText       = "Select Start date"
               datepickerValue = {datePickerValue2}
@@ -88,7 +87,6 @@ class DatePickerPage extends Component {
             />
             <DatePicker
               id              = "someGiantId3"
-              dateFormat      = "mm/dd/yyyy"
               inputState      = {inputState}
               labelText       = "Select End date"
               datepickerValue = {datePickerValue3}
@@ -96,7 +94,7 @@ class DatePickerPage extends Component {
               infoMessage     = {text.textInputInfoMessage}
               errorMessage    = {text.textInputErrorMessage}
             />
-            <p className="code">{`<DatePicker id = "someGiantId" dateFormat = "mm/dd/yyyy" inputState = "default" labelText = "Select date" datepickerValue = {this.state.datepickerValue2} changeHandler = {() => console.log("DatePicker-(basic)-changed!!")} infoMessage = "${text.textInputInfoMessage}" errorMessage = "${text.textInputErrorMessage}" />`}</p>
+            <p className="code">{`<DatePicker id="someGiantId" inputState = "default" labelText = "Select date" datepickerValue = {this.state.datepickerValue2} changeHandler = {() => console.log("DatePicker-(basic)-changed!!")} infoMessage = "${text.textInputInfoMessage}" errorMessage = "${text.textInputErrorMessage}" />`}</p>
 
           </div>
         </div>

--- a/src/Calendar/components/Dates.js
+++ b/src/Calendar/components/Dates.js
@@ -1,119 +1,118 @@
-import React, { Component } from 'react';
+import React from 'react';
 
-export default class Dates extends Component {
-
-  statics = {
+const Dates = (props) => {
+  const statics = {
     year: new Date().getFullYear(),
     month: new Date().getMonth(),
     date: new Date().getDate(),
     today: new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate())
+  };
+
+  let haystack;
+  let day;
+  let d;
+  let current;
+  let onClick;
+  let isDate;
+  let className;
+  let isSecondaryDate;
+  let isCurrentDate;
+  let newSelectedDtClass='';
+  let secondaryString='';
+  let chosenDateString='';
+  let ariaLabel='';
+  const weekStack = Array(...{ length: 7 }).map(Number.call, Number);
+  const { contrast, daysInMonth, firstOfMonth, year, monthNames, month, selectedDate,
+          disablePast, minDate, onSelect, secondaryDate, dayNamesFull,
+          selectedDt, weekStartDay } = props;
+  const dayContrast = contrast ? 'date-inverse' :'';
+  const disabledContrast = contrast ? '-inverse' : '';
+  const that = this;
+  const startDay = firstOfMonth.getUTCDay();
+  const first = firstOfMonth.getDay();
+  const janOne = new Date(year, 0, 1);
+  let rows = 5;
+
+  if (startDay === 5 && daysInMonth === 31 || startDay === 6 && daysInMonth > 29) rows = 6;
+  if (startDay === 0 && daysInMonth === 28) rows = 4;
+
+  className = rows === 6 ? 'pe-cal-dates' : 'pe-cal-dates pe-cal-fix';
+  haystack = Array(...{ length: rows }).map(Number.call, Number);
+  day = weekStartDay + 1 - first;
+  while (day > 1) {
+    day -= 7;
   }
+  day -= 1;
 
-  render() {
-    let haystack;
-    let day;
-    let d;
-    let current;
-    let onClick;
-    let isDate;
-    let className;
-    let isSecondaryDate;
-    let isCurrentDate;
-    let newSelectedDtClass='';
-    let secondaryString='';
-    let chosenDateString='';
-    let ariaLabel='';
-    const weekStack = Array(...{ length: 7 }).map(Number.call, Number);
-    const { contrast, daysInMonth, firstOfMonth, year, monthNames, month, selectedDate,
-            disablePast, minDate, onSelect, secondaryDate, dayNamesFull,
-            selectedDt, weekStartDay } = this.props;
-    const dayContrast = contrast ? 'date-inverse' :'';
-    const disabledContrast = contrast ? '-inverse' : '';
-    const that = this;
-    const startDay = firstOfMonth.getUTCDay();
-    const first = firstOfMonth.getDay();
-    const janOne = new Date(year, 0, 1);
-    let rows = 5;
+  return (
+    <div className={className}
+         role="grid"
+         tabIndex="0"
+         aria-activedescendant={`day${selectedDate}`}
+         aria-labelledby="pe-cal-month"
+    >
+      {haystack.map((item, i) => {
+        d = day + i * 7;
+        return (
+          <div className="pe-cal-row" role="row" key={`row${i}`}>
+            {weekStack.map((item, i) => {
+              d += 1;
+              isDate = d > 0 && d <= daysInMonth;
 
-    if (startDay === 5 && daysInMonth === 31 || startDay === 6 && daysInMonth > 29) rows = 6;
-    if (startDay === 0 && daysInMonth === 28) rows = 4;
+              if (isDate) {
+                current = new Date(year, month, d);
+                className = "pe-cal-cell pe-cal-date";
+                if (disablePast && current < statics.today) {
+                     className += " pe-cal-past";
+                } else if (minDate !== null && current < minDate) {
+                            className += " pe-cal-past";
+                }
 
-    className = rows === 6 ? 'pe-cal-dates' : 'pe-cal-dates pe-cal-fix';
-    haystack = Array(...{ length: rows }).map(Number.call, Number);
-    day = this.props.weekStartDay + 1 - first;
-    while (day > 1) {
-      day -= 7;
-    }
-    day -= 1;
-
-    return (
-      <div className={className}
-           role="grid"
-           tabIndex="0"
-           aria-activedescendant={`day${selectedDate}`}
-           aria-labelledby="pe-cal-month"
-      >
-        {haystack.map((item, i) => {
-          d = day + i * 7;
-          return (
-            <div className="pe-cal-row" role="row" key={`row${i}`}>
-              {weekStack.map((item, i) => {
-                d += 1;
-                isDate = d > 0 && d <= daysInMonth;
-
-                if (isDate) {
-                  current = new Date(year, month, d);
-                  className = "pe-cal-cell pe-cal-date";
-                  if (disablePast && current < that.statics.today) {
-                       className += " pe-cal-past";
-                  } else if (minDate !== null && current < minDate) {
-                              className += " pe-cal-past";
-                  }
-
-                  if (/pe-cal-past/.test(className)) {
-                    return (
-                      <div className={`${className}${disabledContrast} pe-label`}
-                           aria-disabled={true}
-                           id={`day${d}`}
-                           key={`day${d}`}
-                           tabIndex="-1"
-                      >
-                        {d}
-                      </div>
-                    );
-                  }
-                  {isCurrentDate = current.getDate().toString().split(' ')==that.statics.date && firstOfMonth.getMonth().toString().split(' ')==that.statics.month;}
-                  {isSecondaryDate = secondaryDate.some(date => date.getTime()===current.getTime())}
-                  {newSelectedDtClass = (selectedDt.getTime() === current.getTime() && (selectedDt.getDate() !== that.statics.date || selectedDt.getMonth() !== that.statics.month)) ? 'pe-cal-selected' :'';}
-            
-                  {secondaryString = isSecondaryDate ? ' Secondary date' : ''}
-                  {chosenDateString = (selectedDt.getTime() === current.getTime() && (selectedDt.getDate() !== that.statics.date || selectedDt.getMonth() !== that.statics.month)) ? ' Chosen date' : '';}
-                  {ariaLabel = dayNamesFull[i]+' '+monthNames[month]+' '+d+secondaryString+chosenDateString}
-
+                if (/pe-cal-past/.test(className)) {
                   return (
-                    <div className={`${className} pe-label ${dayContrast}`} key={`day${d}`}>
-                      <div className={isCurrentDate ? 'currentDate-box': ''}>
-                         <div className={`pe-cal-cell-square ${isSecondaryDate ? 'secondary-date':''} ${newSelectedDtClass}`}
-                            id={`day${d}`}
-                            role="gridcell"
-                            aria-label={ariaLabel}
-                            aria-current={isCurrentDate ? 'date' : null}
-                            tabIndex="-1"
-                            onClick={onSelect.bind(that, year, month, d)}
-                           >
-                           {d}
-                         </div>
-                       </div>
+                    <div className={`${className}${disabledContrast} pe-label`}
+                         aria-disabled={true}
+                         id={`day${d}`}
+                         key={`day${d}`}
+                         tabIndex="-1"
+                    >
+                      {d}
                     </div>
                   );
                 }
+                {isCurrentDate = current.getDate().toString().split(' ')==statics.date && firstOfMonth.getMonth().toString().split(' ')==statics.month;}
+                {isSecondaryDate = secondaryDate.some(date => date.getTime()===current.getTime())}
+                {newSelectedDtClass = (selectedDt.getTime() === current.getTime() && (selectedDt.getDate() !== statics.date || selectedDt.getMonth() !== statics.month)) ? 'pe-cal-selected' :'';}
 
-                return <div className="pe-cal-cell" key={`day${d}`} />;
-              })}
-            </div>
-          );
-        })}
-      </div>
-    );
-  }
+                {secondaryString = isSecondaryDate ? ' Secondary date' : ''}
+                {chosenDateString = (selectedDt.getTime() === current.getTime() && (selectedDt.getDate() !== statics.date || selectedDt.getMonth() !== statics.month)) ? ' Chosen date' : '';}
+                {ariaLabel = dayNamesFull[i]+' '+monthNames[month]+' '+d+secondaryString+chosenDateString}
+
+                return (
+                  <div className={`${className} pe-label ${dayContrast}`} key={`day${d}`}>
+                    <div className={isCurrentDate ? 'currentDate-box': ''}>
+                       <div className={`pe-cal-cell-square ${isSecondaryDate ? 'secondary-date':''} ${newSelectedDtClass}`}
+                          id={`day${d}`}
+                          role="gridcell"
+                          aria-label={ariaLabel}
+                          aria-current={isCurrentDate ? 'date' : null}
+                          tabIndex="-1"
+                          onClick={onSelect.bind(that, year, month, d)}
+                       >
+                         {d}
+                       </div>
+                     </div>
+                  </div>
+                );
+              }
+
+              return <div className="pe-cal-cell" key={`day${d}`} />;
+            })}
+          </div>
+        );
+      })}
+    </div>
+  );
 };
+
+export default Dates;

--- a/src/Calendar/components/Header.js
+++ b/src/Calendar/components/Header.js
@@ -1,39 +1,35 @@
-import React, { Component } from 'react';
+import React from 'react';
 import Icon from '../../Icon';
 
-export default class Header extends Component {
+const Header = ({onPrev, onNext, month, year, monthNames, contrast}) => {
+  const colorSwap = contrast ? 'inverse-header' :'';
 
-  render() {
-    const { onPrev, onNext, month, year, monthNames, contrast } = this.props;
-    const colorSwap = contrast ? 'inverse-header' :'';
-
-    return (
-      <div className="pe-cal-header pe-title--small">
-        <div className={`pe-cal-title ${colorSwap}`}
-             id="pe-cal-month"
-        >
-               {monthNames[month]}
-               {' '+ year}
-        </div>
-        <button className="pe-arrowIcons pe-icon--btn"
-                onClick={onPrev.bind(this)}
-                type="button"
-                aria-label="Prev month"
-        >
-          <span>
-            <Icon name="chevron-back-18" />
-          </span>
-        </button>
-        <button className="pe-arrowIcons pe-icon--btn"
-                onClick={onNext.bind(this)}
-                type="button"
-                aria-label="Next month"
-        >
-          <span>
-            <Icon name="chevron-next-18" />
-          </span>
-        </button>
+  return (
+    <div className="pe-cal-header pe-title--small">
+      <div className={`pe-cal-title ${colorSwap}`} id="pe-cal-month">
+         {monthNames[month]}
+         {' '+ year}
       </div>
-    );
-  }
+      <button className="pe-arrowIcons pe-icon--btn"
+              onClick={onPrev.bind(this)}
+              type="button"
+              aria-label="Prev month"
+      >
+        <span>
+          <Icon name="chevron-back-18" />
+        </span>
+      </button>
+      <button className="pe-arrowIcons pe-icon--btn"
+              onClick={onNext.bind(this)}
+              type="button"
+              aria-label="Next month"
+      >
+        <span>
+          <Icon name="chevron-next-18" />
+        </span>
+      </button>
+    </div>
+  );
 };
+
+export default Header;

--- a/src/Calendar/components/WeekDays.js
+++ b/src/Calendar/components/WeekDays.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 
 const WeekDays = ({dayNamesFull, dayNames, weekStartDay, contrast}) => {
   const dayNumbers = Array(...{ length: 7 }).map(Number.call, Number);

--- a/src/Calendar/components/WeekDays.js
+++ b/src/Calendar/components/WeekDays.js
@@ -1,26 +1,24 @@
 import React, { Component } from 'react';
 
-export default class WeekDays extends Component {
+const WeekDays = ({dayNamesFull, dayNames, weekStartDay, contrast}) => {
+  const dayNumbers = Array(...{ length: 7 }).map(Number.call, Number);
+  const inverseColor = contrast ? 'inverse-dayNames' :'';
 
-  render() {
-    const { dayNamesFull, dayNames, weekStartDay, contrast } = this.props;
-    const dayNumbers = Array(...{ length: 7 }).map(Number.call, Number);
-    const inverseColor = contrast ? 'inverse-dayNames' :'';
-
-    return (
-      <div className="pe-cal-row pe-cal-weekdays">
-        {dayNumbers.map((item, i) => {
-          return (
-            <div className={`pe-cal-cell pe-label--small pe-cal-cell-dayNames ${inverseColor}`}
-                 key={`weekday${i}`}
-            >
-              <abbr title={dayNamesFull[(weekStartDay + i) % 7]}>
-                {dayNames[(weekStartDay + i) % 7]}
-              </abbr>
-            </div>
-          );
-        })}
-      </div>
-    );
-  }
+  return (
+    <div className="pe-cal-row pe-cal-weekdays">
+      {dayNumbers.map((item, i) => {
+        return (
+          <div className={`pe-cal-cell pe-label--small pe-cal-cell-dayNames ${inverseColor}`}
+               key={`weekday${i}`}
+          >
+            <abbr title={dayNamesFull[(weekStartDay + i) % 7]}>
+              {dayNames[(weekStartDay + i) % 7]}
+            </abbr>
+          </div>
+        );
+      })}
+    </div>
+  );
 };
+
+export default WeekDays;

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -78,7 +78,6 @@ export default class DatePicker extends Component {
     const ariaDescribedby     = em + (infoMessage ? `infoMsg-${id}` : '');
     const mainContainerStyles = className  ? `pe-datepicker-main ${className}`:`pe-datepicker-main`;
     const inputStyles         = inputStyle ? `pe-datepicker-input-styles ${inputStyle}`:`pe-datepicker-input-styles`;
-    const finalDateFormat = dateFormat ? dateFormat : 'mm/dd/yyyy';
 
     return (
       <div
@@ -88,7 +87,7 @@ export default class DatePicker extends Component {
         ref={(dom) => this.container = dom}
       >
         <label className={labelStyleTmp} htmlFor={id}>
-          {`${labelText} (${finalDateFormat})`}
+          {`${labelText} (${dateFormat})`}
         </label>
 
         <div className={containerStyle}>
@@ -152,6 +151,10 @@ DatePicker.propTypes = {
   disablePast   : PropTypes.bool,
   minDate       : PropTypes.object
 };
+
+DatePicker.defaultProps = {
+  dateFormat: 'mm/dd/yyyy'
+}
 
 function _datePickerOpen() {
   const { inputState } = this.state;


### PR DESCRIPTION
While I was changing the event listener yesterday I saw a few opportunities to simplify some things I had done in Calendar.

- Removed unnecessary class based child components in favor of functional components.
- Further destructured props in two of the three child components.
- Changed `dateFormat` in Datepicker to have a defaultProp of the US format to eliminate a variable and from having to include that prop from the consumers end on every instance of the component.