### PR TITLE
chore: Add deprecated flag to package.json and warning to install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pearson-compounds",
   "version": "0.13.4",
-  "description": "Atomic React Components",
+  "description": "**DEPRECATED** Atomic React Components",
   "main": "./build/dist.compounds.js",
   "author": "Pearson Design Accelerator",
   "license": "PEARSON PROPRIETARY AND CONFIDENTIAL INFORMATION SUBJECT TO NDA",


### PR DESCRIPTION
Warning message on install is currently set to "Compounds is no longer undergoing active development.  Please migrate over to @pearson-compounds/elements-sdk"