### PR TITLE
Added props and props.children defaults to empty object getSelectedIndex

### DIFF
--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -248,10 +248,11 @@ export default class Dropdown extends Component {
 
     if (this.props.children) {
       for (let i = 0; i < this.props.children.length; i++) {
-        if (this.props.children[i].props.selected) {
+        const { props = {} } = this.props.children[i] || {};
+        if (props.selected) {
           selectedIndex = i;
           break;
-        }
+        } 
       }
     }
 


### PR DESCRIPTION
Issue with undefined or empty children when setting selected index