### PR TITLE
fix: deal with weird react children

### DIFF
--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -245,7 +245,7 @@ export default class Dropdown extends Component {
   }
 
   getSelectedIndex() {
-    let selectedIndex = 0;
+    let selectedIndex = -1;
 
     if (this.props.children) {
       for (let i = 0; i < this.props.children.length; i++) {
@@ -253,7 +253,7 @@ export default class Dropdown extends Component {
         if (props.selected) {
           selectedIndex = i;
           break;
-        } 
+        }
       }
     }
 

--- a/test/Calendar.test.js
+++ b/test/Calendar.test.js
@@ -50,7 +50,6 @@ describe('Calendar', () => {
       const currentDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
       const month = date.getMonth();
 
-      const wrapper = mount(<Calendar />);
       it('selects a new date', function() {
         const selectedDate = new Date(date.getFullYear(), date.getMonth(), 3);
         const newWrapper = mount(<Calendar newSelectedDt={selectedDate} />)
@@ -59,6 +58,7 @@ describe('Calendar', () => {
       });
 
       it('goes to prev month if not January', function() {
+        const wrapper = mount(<Calendar />);
         if (wrapper.node.state.month > 0) {
           wrapper.find('[aria-label="Prev month"]').simulate('click');
           expect(wrapper.node.state.month).toEqual(month - 1);
@@ -66,6 +66,7 @@ describe('Calendar', () => {
       });
 
       it('goes to next month if not December', function() {
+        const wrapper = mount(<Calendar />);
         if (wrapper.node.state.month < 11) {
           wrapper.find('[aria-label="Next month"]').simulate('click');
           expect(wrapper.node.state.month).toEqual(month + 1);
@@ -73,6 +74,7 @@ describe('Calendar', () => {
       });
 
       it('goes to prev month if January', function() {
+        const wrapper = mount(<Calendar />);
         if (wrapper.node.state.month === 0) {
           wrapper.find('[aria-label="Prev month"]').simulate('click');
           expect(wrapper.node.state.month).toEqual(11);
@@ -80,6 +82,7 @@ describe('Calendar', () => {
       });
 
       it('goes to next month if December', function() {
+        const wrapper = mount(<Calendar />);
         if (wrapper.node.state.month === 11) {
           wrapper.find('[aria-label="Next month"]').simulate('click');
           expect(wrapper.node.state.month).toEqual(0);


### PR DESCRIPTION
Starts selectedIndex check at -1 so only valid children will get the selectedIndex value; undefined and other values are sometimes passed in to children as we build up the structure